### PR TITLE
Allowed origins

### DIFF
--- a/kong/plugins/openwhisk/schema.lua
+++ b/kong/plugins/openwhisk/schema.lua
@@ -1,7 +1,5 @@
 local typedefs = require "kong.db.schema.typedefs"
 
-local _MAP_VALUES_TYPES = { "boolean", "set", "array", "string", "integer", "number", "map" }
-
 return {
   name = "openwhisk",
   fields = {
@@ -9,24 +7,32 @@ return {
     { config = {
         type = "record",
         fields = {
-          { timeout       = { type = "integer", default  = 60000 } },
-          { keepalive     = { type = "integer", default  = 60000 } },
-          { service_token = { type = "string"                     } },
-          { host          = typedefs.host({ required = true }), },
-          { port          = typedefs.port({ required = true, default = 443 }), },
-          { path          = { type = "string",  required = true   } },
-          { action        = { type = "string",  required = true   } },
-          { https         = { type = "boolean", default  = true   } },
-          { https_verify  = { type = "boolean", default  = false  } },
-          { result        = { type = "boolean", default  = true   } },
-          { environment   = { type = "string",  default  = "{}"   } },
-          { parameters    = { type = "string",  default  = "{}"   } },
-          { methods        = {
+          { timeout         = { type = "integer", default  = 60000 } },
+          { keepalive       = { type = "integer", default  = 60000 } },
+          { service_token   = { type = "string"                     } },
+          { host            = typedefs.host({ required = true }), },
+          { port            = typedefs.port({ required = true, default = 443 }), },
+          { path            = { type = "string",  required = true   } },
+          { action          = { type = "string",  required = true   } },
+          { https           = { type = "boolean", default  = true   } },
+          { https_verify    = { type = "boolean", default  = false  } },
+          { result          = { type = "boolean", default  = true   } },
+          { environment     = { type = "string",  default  = "{}"   } },
+          { parameters      = { type = "string",  default  = "{}"   } },
+          { methods         = {
               type = "array",
               default  = { "POST" },
               elements = {
                 type = "string",
                 one_of = { "HEAD", "GET", "POST", "PATCH", "PUT" }
+              }
+            }
+          },
+          { allowed_origins = {
+              type = "array",
+              default  = {},
+              elements = {
+                type = "string",
               }
             }
           },


### PR DESCRIPTION
In this pull request, I added support to Apache openwhisk for validating the origin of the HTTP request. The validations include:

1. If the "allowed_origins" is empty, all origins are valid.
2. If there are 1 o more elements in "allowed_origins" list and the origin header is nil, return 403
3. If the Origin header isn't nil and there are options in "allowed_origins", It validates each one until finding a pattern that includes the request origin or until not found a valid pattern inside the list.