### PR TITLE
Back/dev 936 fixing functions

### DIFF
--- a/kong/plugins/openwhisk/handler.lua
+++ b/kong/plugins/openwhisk/handler.lua
@@ -185,10 +185,14 @@ function OpenWhisk:access(config)
   end
 
   -- Append environment data
-  -- body['_environment'] = config.environment
+  if config.environment ~= nil then
+    body['_environment'] = config.environment
+  end
 
   -- Append extra data for the request
-  -- body['_parameters'] = config.parameters
+  if config.parameters ~= nil then
+    body['_parameters'] = config.parameters
+  end
 
   -- Get x-auth-token
   local authorization_header = get_headers()["x-auth-token"]

--- a/kong/plugins/openwhisk/handler.lua
+++ b/kong/plugins/openwhisk/handler.lua
@@ -185,10 +185,10 @@ function OpenWhisk:access(config)
   end
 
   -- Append environment data
-  body['_environment'] = config.environment
+  -- body['_environment'] = config.environment
 
   -- Append extra data for the request
-  body['_parameters'] = config.parameters
+  -- body['_parameters'] = config.parameters
 
   -- Get x-auth-token
   local authorization_header = get_headers()["x-auth-token"]


### PR DESCRIPTION
Using _environment and _parameters variables only if they are not nil, otherwise they are discarded.